### PR TITLE
34 bug 38 bundle reload 失败

### DIFF
--- a/extensions/MKFramework/assets/.eslintrc
+++ b/extensions/MKFramework/assets/.eslintrc
@@ -3,7 +3,7 @@
  * "warn" 或 1 - 开启规则，使用警告级别的错误：warn (不会导致程序退出),
  * "error" 或 2 - 开启规则，使用错误级别的错误：error (当被触发的时候，程序会退出)
  */
-{
+ {
 	"parser": "@typescript-eslint/parser",
 	"parserOptions": {
 		"requireConfigFile": false,
@@ -17,17 +17,30 @@
 		"browser": false,
 		"node": false
 	},
-	"ignorePatterns": ["tool/**"],
-	"globals": {},
+	"globals": {
+		"self": true
+	},
 	"rules": {
 		// 禁止全局变量
 		"no-restricted-globals": ["error", "Node"],
 		// 禁止导入
-		"@typescript-eslint/no-restricted-imports": ["off"],
+		"@typescript-eslint/no-restricted-imports": ["error",
+			{
+				"patterns": [
+					// 禁止使用 @framework 内的模块
+					{
+						"group": ["@framework"],
+						"message": "请使用 mk.xxx，而不是直接导入 @framework"
+					}
+				],
+				// 禁止使用 NodeJs 模块
+				"paths": ["assert","buffer","child_process","cluster","crypto","dgram","dns","domain","events","freelist","fs","http","https","module","net","os","path","punycode","querystring","readline","repl","smalloc","stream","string_decoder","sys","timers","tls","tracing","tty","url","util","vm","zlib"]
+			}
+		],
 		// 禁止返回类型 void 混合其他
 		"@typescript-eslint/no-invalid-void-type": "error",
 		// 一致的泛型构造函数
-		"@typescript-eslint/consistent-generic-constructors": ["error", "constructor"],
+		"@typescript-eslint/consistent-generic-constructors": "error",
 		// 使用 Record 代替 { [k: type]: type }
 		"@typescript-eslint/consistent-indexed-object-style": ["error", "record"],
 		// 不允许使用大类型
@@ -66,10 +79,6 @@
 		"@typescript-eslint/prefer-optional-chain": "error",
 		// 禁止使用联合或可选/剩余参数可以统一为一个的两个重载
 		"@typescript-eslint/unified-signatures": "error",
-		// 在显式类型转换上强制执行非空断言（测试无效）
-		"@typescript-eslint/non-nullable-type-assertion-style": "error",
-		// 强制使用 nullish 合并运算符而不是逻辑链（测试无效）
-		"@typescript-eslint/prefer-nullish-coalescing": "error",
 		// 一致的类型断言
 		"@typescript-eslint/consistent-type-assertions": ["error", { "assertionStyle": "as", "objectLiteralTypeAssertions": "never" }],
 		// 必须存在返回类型
@@ -81,7 +90,7 @@
 			}
 		],
 		// 类成员换行
-		"@typescript-eslint/lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
+		"@typescript-eslint/lines-between-class-members": ["error", { "exceptAfterSingleLine": true }],
 		// 换行规则
 		"@typescript-eslint/padding-line-between-statements": [
 			"error",

--- a/extensions/MKFramework/assets/.prettierrc.json
+++ b/extensions/MKFramework/assets/.prettierrc.json
@@ -10,20 +10,5 @@
 	"endOfLine": "lf",
 	"htmlWhitespaceSensitivity": "ignore",
 	"trailingComma": "es5",
-	"parser": "typescript",
-	"overrides": [
-    	{
-			"files": "*.ts",
-			"options": {
-				"useTabs": false,
-				"tabWidth": 4,
-				"printWidth": 80,
-				"semi": true,
-				"singleQuote": true,
-				"bracketSpacing": true,
-				"arrowParens": "always",
-				"trailingComma": "all"
-			}
-		}
-	]
+	"parser": "typescript"
 }

--- a/extensions/MKFramework/assets/.prettierrc.json
+++ b/extensions/MKFramework/assets/.prettierrc.json
@@ -1,0 +1,29 @@
+{
+	"printWidth": 150,
+	"tabWidth": 4,
+	"useTabs": true,
+	"semi": true,
+	"singleQuote": false,
+	"proseWrap": "preserve",
+	"arrowParens": "always",
+	"bracketSpacing": true,
+	"endOfLine": "lf",
+	"htmlWhitespaceSensitivity": "ignore",
+	"trailingComma": "es5",
+	"parser": "typescript",
+	"overrides": [
+    	{
+			"files": "*.ts",
+			"options": {
+				"useTabs": false,
+				"tabWidth": 4,
+				"printWidth": 80,
+				"semi": true,
+				"singleQuote": true,
+				"bracketSpacing": true,
+				"arrowParens": "always",
+				"trailingComma": "all"
+			}
+		}
+	]
+}

--- a/extensions/MKFramework/assets/mk-framework/@framework/module/mk_view_base.ts
+++ b/extensions/MKFramework/assets/mk-framework/@framework/module/mk_view_base.ts
@@ -174,9 +174,6 @@ export class mk_view_base extends mk_life_cycle {
 		/** 打开动画函数 */
 		const open_animation_f = mk_view_base._config.window_animation_tab?.open?.[this.animation_config?.open_animation_s];
 
-		// 更新 widget，防止在节点池内 widget 未更新
-		cc.view.emit("canvas-resize");
-
 		// 打开动画
 		if (open_animation_f) {
 			await open_animation_f(this.node);

--- a/extensions/MKFramework/assets/mk-framework/@framework/resources/mk_bundle.ts
+++ b/extensions/MKFramework/assets/mk-framework/@framework/resources/mk_bundle.ts
@@ -159,13 +159,7 @@ export class mk_bundle extends mk_instance_base {
 	 */
 	async load(args_: string | mk_bundle_.load_config): Promise<cc.AssetManager.Bundle | null> {
 		/** 加载配置 */
-		const load_config =
-			typeof args_ === "string"
-				? new mk_bundle_.load_config({
-						bundle_s: args_,
-				  })
-				: args_;
-
+		const load_config = typeof args_ === "string" ? new mk_bundle_.load_config({ bundle_s: args_ }) : args_;
 		/** bundle 信息 */
 		const bundle_info = this.bundle_map.get(load_config.bundle_s!) ?? new mk_bundle_.bundle_info(load_config);
 

--- a/extensions/MKFramework/assets/mk-framework/@framework/resources/mk_bundle.ts
+++ b/extensions/MKFramework/assets/mk-framework/@framework/resources/mk_bundle.ts
@@ -345,7 +345,7 @@ export class mk_bundle extends mk_instance_base {
 	 * @param bundle_ bundle 信息
 	 * @returns
 	 */
-	async reload(bundle_: mk_bundle_.bundle_info & Required<Pick<mk_bundle_.bundle_info, "origin_s">>): Promise<cc.AssetManager.Bundle | null> {
+	async reload(bundle_: Required<mk_bundle_.bundle_info>): Promise<cc.AssetManager.Bundle | null> {
 		if (PREVIEW) {
 			this._log.error("不支持预览模式重载 bundle");
 


### PR DESCRIPTION
- 移除了框架内对 canvas-resize 事件的使用（3.8.2）测试 editbox 组件未取消监听
- 规定了 mk.bundle.reload 必须传递版本号，不再支持无版本 bundle 脚本热更