### PR TITLE
Potential fix for code scanning alert no. 1: Useless regular-expression character escape

### DIFF
--- a/plugin/quick-store/panel/store.ts
+++ b/plugin/quick-store/panel/store.ts
@@ -275,7 +275,7 @@ export let methods = {
 		/** 文件名 */
 		let file_name_s =
 			content_s.match(
-				new RegExp(`(?<=(${download_url_s}\\">))([^]+?)(?=\.zip)`, "g")
+				new RegExp(`(?<=(${download_url_s}\\">))([^]+?)(?=\\.zip)`, "g")
 			)?.[0] ?? "";
 
 		if (file_name_s === "") {


### PR DESCRIPTION
Potential fix for [https://github.com/1226085293/MKFramework/security/code-scanning/1](https://github.com/1226085293/MKFramework/security/code-scanning/1)

To fix the problem, we need to ensure that the escape sequence `\.` is correctly interpreted as a literal dot in the regular expression. This can be achieved by adding an extra backslash to properly escape the dot character in the string literal.

- Change the escape sequence `\.` to `\\.` in the string literal used to construct the regular expression.
- This change should be made on line 278 of the file `plugin/quick-store/panel/store.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
