### PR TITLE
单独展示区分层级大小

### DIFF
--- a/extensions/MKFramework/assets/MKFramework/Framework/MKUIManage.ts
+++ b/extensions/MKFramework/assets/MKFramework/Framework/MKUIManage.ts
@@ -468,7 +468,7 @@ export class MKUIManage extends MKInstanceBase {
 		// 更新单独展示
 		if (viewComp.isShowAlone) {
 			this._uiShowList.slice(this._uiHiddenLengthN, this._uiShowList.length).forEach((v) => {
-				if (v.valid && v.node.active) {
+				if (v.valid && v.node.active && v.orderNum < viewComp.orderNum) {
 					this._uiHiddenSet.add(v);
 					v.node.active = false;
 				}

--- a/extensions/MKFramework/assets/MKFramework/Framework/Module/MKLayer.ts
+++ b/extensions/MKFramework/assets/MKFramework/Framework/Module/MKLayer.ts
@@ -59,7 +59,11 @@ class MKLayer extends Component {
 		this._childLayerNum = valueNum_;
 		this._updateLayer();
 	}
-
+	/* --------------- paragraph --------------- */
+	/** 真实渲染次序 */
+	get orderNum(): number {
+		return this.layerTypeNum * MKLayer._config.layerSpacingNum + this._childLayerNum;
+	}
 	/* --------------- protected --------------- */
 	/**
 	 * 使用 layer
@@ -103,11 +107,8 @@ class MKLayer extends Component {
 			return;
 		}
 
-		/** 当前层 */
-		const layerNum = this.layerTypeNum * MKLayer._config.layerSpacingNum + this._childLayerNum;
-
 		// 更新渲染顺序
-		MKN(this.node).orderNum = layerNum;
+		MKN(this.node).orderNum = this.orderNum;
 	}
 }
 


### PR DESCRIPTION
修改前：单独展示内容层的UI时，会隐藏之前打开的层级更高的UI
修改后：会跳过比自己层级更高或者相同的UI